### PR TITLE
added temporary selling ignore list

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Blade is a WoW Addon that aims to make the game easier by providing convenience 
     - Guild and/or normal
 - Auto Vendor
     - Trash items
-    - Other whitelisted items
+    - Any item set to be sold
 - Auto insert M+ keys
 - Auto complete Missions on SL Mission Table
 - Save and restore actionbar profiles

--- a/src/api/ContainerItem.ts
+++ b/src/api/ContainerItem.ts
@@ -40,4 +40,9 @@ export class ContainerItem {
     public IsValid(): boolean {
         return this.itemLocation.IsValid()
     }
+
+    private _lookupKey?: string
+    public get lookupKey(): string {
+        return this._lookupKey ??= `${this.containerIndex}_${this.slotIndex}`
+    }
 }


### PR DESCRIPTION
added a temporary ignore list to items sold to accommodate for server lag and prevent items from reselling which have already been sold for a smoother experience